### PR TITLE
Add hint if author has more extensions than shown

### DIFF
--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -37,6 +37,7 @@ $lang['bugtracker']          = 'Report bugs';
 $lang['sourcerepo']          = 'Repository';
 $lang['source']              = 'Source';
 $lang['donationurl']         = 'Donate';
+$lang['more_extensions']     = 'and %d more';
 
 // Plugin table
 $lang['t_search_plugins']    = 'Search Plugins';

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -349,10 +349,15 @@ class syntax_plugin_pluginrepo_entry extends DokuWiki_Syntax_Plugin {
 
         // other extensions by the same author (10 max)
         if (count($rel['sameauthor']) > 0) {
+            $maxShow = 10;
             $itr = 0;
             $R->doc .= '<ul>'.NL;
-            while ($itr < count($rel['sameauthor']) && $itr < 10) {
+            while ($itr < count($rel['sameauthor']) && $itr < $maxShow) {
                 $R->doc .= '<li>'.$this->hlp->pluginlink($R,$rel['sameauthor'][$itr++]).'</li>'.NL;
+            }
+            if (count($rel['sameauthor']) > $maxShow) {
+                $remainingExtensions = count($rel['sameauthor'])-$maxShow;
+                $R->doc .= '<li>'.sprintf($this->getLang('more_extensions'), $remainingExtensions).'</li>';
             }
             $R->doc .= '</ul>'.NL;
         }


### PR DESCRIPTION
I first wanted to report a bug that the bottom line of each extension entry is missing lots of extensions by the same author when I found in the code that it has always been like that, so most probably intentional. I wrote the original code for that (although I don't remember that at all ;-) ) and there is a restriction to only show the first 10 extensions.

This PR adds one hint at the end of that list how many more extensions there are by the same author.
E.g. if you have written 21 extensions, the list will still only show 10 of them but add at the end "and 11 more".