### PR TITLE
Fix compatibility box width overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -113,7 +113,6 @@
     top: 0;
     left: 0;
     box-shadow: 0 5px 5px #999;
-    width: 300px;
     overflow: visible;
     border: 2px solid __background__;
     margin: -2px -2px 0;
@@ -122,6 +121,7 @@
 .dokuwiki div.pluginrepo_entry div.compatibility li {
     display: none;
     color: __text__ !important;
+    clear: both;
 }
 .dokuwiki div.pluginrepo_entry div.compatibility li:first-child {
     display: block;


### PR DESCRIPTION
This fixes compatibility box width overflow.

> If the table of contents is folded, then the "Compatible with DokuWiki" box is partly hidden and the assigned value for a specific DokuWiki release (e.g. "Yes") cannot be seen.

Fixes #134. Related to #121 (not sure how to deal with that PR though).