### PR TITLE
Align compatibility box to the right for overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -111,7 +111,7 @@
 .dokuwiki div.pluginrepo_entry div.compatibility ul:hover {
     position: absolute;
     top: 0;
-    left: 0;
+    right: 0;
     box-shadow: 0 5px 5px #999;
     width: 300px;
     overflow: visible;


### PR DESCRIPTION
This fixes compatibility box width overflow (previously it just overlays above the TOC).

> If the table of contents is folded, then the "Compatible with DokuWiki" box is partly hidden and the assigned value for a specific DokuWiki release (e.g. "Yes") cannot be seen.

Fixes #134. Related to #130.