### PR TITLE
Fix display of mail icon in plugin information

### DIFF
--- a/style.css
+++ b/style.css
@@ -196,10 +196,6 @@
     font-size: 120%;
     font-weight: normal;
 }
-.dokuwiki div.pluginrepo_entry div.authorInfo strong a.mail {
-    background-position: 0 2px;
-    padding-left: 18px;
-}
 .dokuwiki div.pluginrepo_entry div.authorInfo ul {
     margin-bottom: 0;
 }


### PR DESCRIPTION
- Icon appeared lower than rest of line
- Missing space between icon and author's name

| Before | After |
|---|---|
|<img width="198" alt="image" src="https://user-images.githubusercontent.com/449891/193402127-2cae19d6-9e71-4f76-9139-2dd9b8879b2a.png">|<img width="198" alt="image" src="https://user-images.githubusercontent.com/449891/193402152-f584ae2b-c577-4823-b71a-170c80a5f719.png">|